### PR TITLE
fix: implement correct I can help counter flow

### DIFF
--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -16,6 +16,7 @@ import { Switch } from "../components/ui/switch";
 import { 
   useCreateInteractionApiV1InteractionsPost 
 } from "../api-client/api-client";
+import { useCacheManager } from "../hooks/useCacheManager";
 import { InteractionTarget, InteractionType } from "../api-client/models";
 import { useAppStore } from "../stores/appStore";
 import { useAuthStore } from "../stores/authStore";
@@ -29,6 +30,7 @@ export const Chat: React.FC = () => {
   const location = useLocation();
   const { user } = useAuthStore();
   const { chatThreads, messages, addMessage, setMessages, questions, incrementQuestionHelpCount } = useAppStore();
+  const { afterInteraction } = useCacheManager();
   
   const [newMessage, setNewMessage] = useState("");
   const [isPublicVisible, setIsPublicVisible] = useState(true); // Default: ON
@@ -162,6 +164,9 @@ export const Chat: React.FC = () => {
               }
             });
             console.log("Help interaction recorded successfully");
+            
+            // Invalidate caches to refresh question data and counts
+            afterInteraction(question.id);
           } catch (error) {
             console.error("Failed to record help interaction:", error);
             // Continue with the flow even if API fails

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -76,6 +76,9 @@ export const Home: React.FC = () => {
     return rawQuestions.map((question) => {
       const userData = getQuestionUserData(question);
       
+      // Access interaction counts from backend response (they might not be in TypeScript types yet)
+      const questionWithCounts = question as any;
+      
       return {
         id: question.id,
         authorId: question.user_id,
@@ -90,9 +93,9 @@ export const Home: React.FC = () => {
         createdAt: question.created_at || new Date().toISOString(),
         visibility: "anyone" as const,
         isAnonymous: question.is_anonymous || false,
-        upvotes: 0, // Will be calculated from interactions
-        meTooCount: 0, // Will be calculated from interactions  
-        canHelpCount: 0, // Will be calculated from interactions
+        upvotes: questionWithCounts.uplifts_count || 0, // Real count from backend
+        meTooCount: questionWithCounts.me_too_count || 0, // Real count from backend  
+        canHelpCount: questionWithCounts.i_can_help_count || 0, // Real count from backend
         isUpvoted: false, // Will be determined from user's interactions
         isMeToo: false, // Will be determined from user's interactions
         isBookmarked: false, // Will be determined from user's interactions


### PR DESCRIPTION
## Summary
- Fixes "I can help" counter to increment only when users actually send help messages, not on button clicks
- Adds cache invalidation to Chat.tsx after creating i_can_help interaction
- Updates Home.tsx to use real backend interaction counts instead of hardcoded zeros

## Changes
- **Chat.tsx**: Added cache invalidation with `afterInteraction(question.id)` after creating interaction
- **Home.tsx**: Access real backend counts (`i_can_help_count`, `me_too_count`, `uplifts_count`) instead of hardcoded `0`

## Flow
1. ✅ User clicks "I can help" button → chat opens (no counter increment)
2. ✅ User sends help message with public visibility → interaction created + counter increments  
3. ✅ User sends help message with private visibility → no interaction created + no counter increment
4. ✅ Cache invalidated → Home.tsx shows updated counts from backend

## Test Plan
- [ ] Click "I can help" button - should open chat without incrementing counter
- [ ] Send help message with toggle ON - should increment counter after message sent
- [ ] Send help message with toggle OFF - should not increment counter
- [ ] Return to Home - should show updated count from backend
- [ ] Verify other interaction counts (upvotes, me too) still work